### PR TITLE
giflib >5 fix in canvas

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "obj-extend": "~0.1.0",
     "temporary": "0.0.5",
     "async": "~0.2.7",
-    "canvas": "~1.0.2"
+    "canvas": "~1.1.1"
   },
   "devDependencies": {
     "grunt": "~0.3.17",


### PR DESCRIPTION
node-canvas was updated in LearnBoost/node-canvas@a0632275c53d0ed4811a96fb7bf12ebd5668f289 to work with `giflib`>5. That commit was released as version v1.1.1 and thus requires an update of package.json.

Passes `npm test`
