### PR TITLE
Bumping canvas version to ~1.6.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "async": "~0.2.7",
-    "canvas": "~1.3.15",
+    "canvas": "~1.6.11",
     "concat-stream": "~1.5.1",
     "vinyl-file": "~1.3.0"
   },


### PR DESCRIPTION
The current version of canvas does not work on MacOS 10.13.4 (and potentially more).