### PR TITLE
Upgraded node-canvas to latest version and updated Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@
 [spritesmith]: https://github.com/Ensighten/spritesmith
 
 ## Requirements
-Due to dependance on [node-canvas][canvas], you must install [Cairo][].
+By default, binaries for macOS, Linux and Windows will be downloaded.
+But if you don't have a supported OS or processor architecture the module will be compiled on your system.
+This requires several dependencies from [node-canvas][canvas], you must install [Cairo][] and Pango.
 
 Instructions on how to do this are provided in the [node-canvas wiki][canvas-wiki].
 

--- a/lib/canvas.js
+++ b/lib/canvas.js
@@ -1,6 +1,6 @@
 // Load in our dependencies
 var assert = require('assert');
-var NodeCanvas = require('canvas');
+var NodeCanvas = require('canvas').Canvas;
 
 // Define our canvas constructor
 function Canvas(width, height) {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "async": "~0.2.7",
-    "canvas": "~1.6.11",
+    "canvas": "~2.6.1",
     "concat-stream": "~1.5.1",
     "vinyl-file": "~1.3.0"
   },


### PR DESCRIPTION
Now node-canvas support [node-canvas-prebuilt](https://github.com/chearon/node-canvas-prebuilt) from box and doesn't require dependencies. So it's easier to use it for most users.
If you don't have a supported OS or processor architecture the module will be compiled on your system and you still need install dependencies in this case.
In node-canvas from 2.x was changes in export from the module [CHANGELOG](https://github.com/Automattic/node-canvas/blob/master/CHANGELOG.md#200)