### PR TITLE
Update Node.js versions in Travis CI + update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,9 @@
 sudo: false
 language: node_js
 node_js:
-  - "9"
-  - "8"
-  - "6"
-matrix:
-  allow_failures:
-    - node_js: "9"
+  - "16"
+  - "14"
+  - "12"
 
 # Use `apt` from `node-canvas`
 # https://github.com/Automattic/node-canvas/blob/v1.3.0/.travis.yml#L14-L19

--- a/package.json
+++ b/package.json
@@ -27,18 +27,18 @@
     "test": "npm run precheck && mocha --reporter dot --timeout 60000 && npm run lint"
   },
   "dependencies": {
-    "async": "~0.2.7",
-    "canvas": "~2.6.1",
-    "concat-stream": "~1.5.1",
+    "async": "~1.5.2",
+    "canvas": "~2.7.0",
+    "concat-stream": "~1.6.2",
     "vinyl-file": "~1.3.0"
   },
   "devDependencies": {
-    "foundry": "~4.3.2",
-    "foundry-release-git": "~2.0.2",
-    "foundry-release-npm": "~2.0.2",
-    "jscs": "~2.4.0",
-    "jshint": "~2.8.0",
-    "mocha": "~1.21.4",
+    "foundry": "~4.6.0",
+    "foundry-release-git": "~2.0.5",
+    "foundry-release-npm": "~2.0.3",
+    "jscs": "~3.0.7",
+    "jshint": "~2.12.0",
+    "mocha": "~8.4.0",
     "spritesmith-engine-test": "~5.0.0",
     "twolfson-style": "~1.6.1"
   },


### PR DESCRIPTION
Note: The update on the `async` dependency (0.2.7 to 1.5.2) may be a breaking change in theory, but in practice the tests still pass after the update. So it does not look like a breaking change to me. If you are not comfortable with that version change, then feel free to revert to 0.2.7.